### PR TITLE
Fixed error in Issue #29

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,4 +1,5 @@
 <script setup>
+const backendSettings = ref(null);
 const calendarViewType = ref("Monthly");
 const displayText = ref("");
 const months = [
@@ -85,7 +86,7 @@ function updateDates() {
   // Check which day the first day of the month falls on
   // If not the start of the week, add the previous month's dates
   // Get the start day from settings
-  const settings = JSON.parse(localStorage.getItem("settings")) || {};
+  const settings = backendSettings.value.getSettings();
   const startDay = settings.startWeekOn.substring(0, 3).toUpperCase() || "SUN";
 
   d = new Date(year, month);
@@ -273,6 +274,7 @@ function navigateCalendar(view, direction) {
       </div>
     </div>
   </div>
+  <BackendSettings ref="backendSettings" />
 </template>
 
 <style scoped>


### PR DESCRIPTION
Fixed the error highlighted in Issue #29. See the issue for detailed information.

Error was resolved by utilizing the getSettings() function provided by BackendSettings component. The mentioned function provides a default object for settings in the scenario whereby the settings were not initialized yet. 

Related PR: #27 